### PR TITLE
point "main" in package.json to src/index.js, fixes #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-inky",
   "version": "0.1.0",
   "description": "React components for Inky",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "docs:build": "gitbook build",
     "docs:serve": "gitbook serve",


### PR DESCRIPTION
hey!

i really like the idea of this project. thanks for all your work!

i noticed that i wasn't able to import this project. it looks like this _mostly_ does it. however, it's still up to the consumer to transpile this code into something more usable.

could we set something up to handle that? i think the common approach is a `prepublish` script to `babel src/ -d lib/`, and then point `main` to `lib/index.js`.

let me know what you think! thanks again ⭐️ 