### PR TITLE
ensure child exists before checking child.type

### DIFF
--- a/src/util/containsRow.js
+++ b/src/util/containsRow.js
@@ -8,8 +8,8 @@ import { Children } from 'react';
 export default function containsRow(children) {
   let hasRow = false;
 
-  Children.map(children, child => {
-    if (typeof child.type === 'function' && child.type.name === 'Row') {
+  Children.forEach(children, child => {
+    if (child && typeof child.type === 'function' && child.type.name === 'Row') {
       hasRow = true;
     }
   });


### PR DESCRIPTION
i was running into issues where `child` is undefined, giving me a `Cannot read property 'type' of undefined`. it appears to be fixed now.

i also switch the `map` to a `forEach` since there's no return value