### PR TITLE
Preserve valign attribute

### DIFF
--- a/src/util/getAttrs.js
+++ b/src/util/getAttrs.js
@@ -31,8 +31,9 @@ export default function getAttrs(props, tag, className = '') {
   // `style` isn't included in `filterPropsFor` and must be copied manually
   if (props.style) output.style = props.style
 
-  // Same with `align`, since it's a deprecated attribute
+  // Same with `align` and `valign`, since they are deprecated attributes
   if (props.align) output.align = props.align;
+  if (props.valign) output.valign = props.valign;
 
   return output;
 }


### PR DESCRIPTION
Zurb recommends the deprecated `valign` prop for emails (see 
https://foundation.zurb.com/emails/docs/alignment.html), but react-attrs-filter is removing it.