### PR TITLE
Pass all props to result html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -413,9 +413,9 @@
           "dev": true
         },
         "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
           "dev": true
         },
         "debug": {
@@ -486,9 +486,9 @@
           }
         },
         "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -12192,14 +12192,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0"
-      }
-    },
-    "react-attrs-filter": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/react-attrs-filter/-/react-attrs-filter-0.1.2.tgz",
-      "integrity": "sha1-lrZhziEHW3uW7H0qzpen5oi2QMA=",
-      "requires": {
-        "babel-runtime": "5.8.x"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   "homepage": "https://github.com/gakimball/react-inky#readme",
   "dependencies": {
     "classnames": "^2.2.6",
-    "prop-types": "^15.6.2",
-    "react-attrs-filter": "^0.1.2"
+    "prop-types": "^15.6.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.11.1",
     "babel-register": "^6.26.0",

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -6,7 +6,7 @@ export default function Button(props) {
   const expanded = props.className.match('expand') !== null;
 
   return (
-    <table {...getAttrs(props, 'button')}>
+    <table {...getAttrs(props, ['href', 'target', 'children'], 'button')}>
       <tr>
         <td>
           <table>

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -6,7 +6,7 @@ export default function Button(props) {
   const expanded = props.className.match('expand') !== null;
 
   return (
-    <table {...getAttrs(props, 'table', 'button')}>
+    <table {...getAttrs(props, 'button')}>
       <tr>
         <td>
           <table>

--- a/src/components/Callout.js
+++ b/src/components/Callout.js
@@ -4,7 +4,7 @@ import getAttrs from '../util/getAttrs';
 
 export default function Callout(props) {
   return (
-    <table {...getAttrs(props, 'table', 'callout')}>
+    <table {...getAttrs(props, 'callout')}>
       <tr>
         <th className="callout-inner">{props.children}</th>
         <th className="expander"/>

--- a/src/components/Callout.js
+++ b/src/components/Callout.js
@@ -4,7 +4,7 @@ import getAttrs from '../util/getAttrs';
 
 export default function Callout(props) {
   return (
-    <table {...getAttrs(props, 'callout')}>
+    <table {...getAttrs(props, ['children'], 'callout')}>
       <tr>
         <th className="callout-inner">{props.children}</th>
         <th className="expander"/>

--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -28,7 +28,7 @@ export default function Column(props) {
   return (
     <ContainerContext.Consumer>
       {({columnCount}) => (
-        <th {...getAttrs(props, 'th', getColumnClasses(props, columnCount))}>
+        <th {...getAttrs(props, getColumnClasses(props, columnCount))}>
           <table>
             <tr>
               <th>{props.children}</th>

--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -28,7 +28,7 @@ export default function Column(props) {
   return (
     <ContainerContext.Consumer>
       {({columnCount}) => (
-        <th {...getAttrs(props, getColumnClasses(props, columnCount))}>
+        <th {...getAttrs(props, ['children', 'expander', 'first', 'last'], getColumnClasses(props, columnCount))}>
           <table>
             <tr>
               <th>{props.children}</th>

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -14,14 +14,18 @@ import ContainerContext from '../util/containerContext';
  *   Lorem ipsum dolor sit amet.
  * </Container>
  */
-const Container = props => (
-  <ContainerContext.Provider
+const Container = props => {
+  const rest = Object.assign({}, props);
+  delete rest.columnCount;
+  delete rest.strictMode;
+
+  return <ContainerContext.Provider
     value={{
       columnCount: props.columnCount,
       strictMode: props.strictMode
     }}
-  >
-    <table align="center" {...getAttrs(props, 'table', 'container')}>
+  >  
+    <table align="center" {...getAttrs(rest, 'container')}>
       <tbody>
         <tr>
           <td>{props.children}</td>
@@ -29,7 +33,7 @@ const Container = props => (
       </tbody>
     </table>
   </ContainerContext.Provider>
-);
+};
 
 /**
  * Prop types for `<Container />`.

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -14,26 +14,21 @@ import ContainerContext from '../util/containerContext';
  *   Lorem ipsum dolor sit amet.
  * </Container>
  */
-const Container = props => {
-  const rest = Object.assign({}, props);
-  delete rest.columnCount;
-  delete rest.strictMode;
-
-  return <ContainerContext.Provider
+const Container = props => (
+  <ContainerContext.Provider
     value={{
       columnCount: props.columnCount,
       strictMode: props.strictMode
     }}
-  >  
-    <table align="center" {...getAttrs(rest, 'container')}>
+  >
+    <table align="center" {...getAttrs(props, ['columnCount', 'strictMode', 'children'], 'container')}>
       <tbody>
         <tr>
           <td>{props.children}</td>
         </tr>
       </tbody>
     </table>
-  </ContainerContext.Provider>
-};
+  </ContainerContext.Provider>);
 
 /**
  * Prop types for `<Container />`.

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -4,7 +4,7 @@ import getAttrs from '../util/getAttrs';
 
 export default function Item(props) {
   return (
-    <th {...getAttrs(props, 'menu-item')}>
+    <th {...getAttrs(props, ['href', 'target', 'children'], 'menu-item')}>
       <a href={props.href} target={props.target}>{props.children}</a>
     </th>
   );

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -4,7 +4,7 @@ import getAttrs from '../util/getAttrs';
 
 export default function Item(props) {
   return (
-    <th {...getAttrs(props, 'th', 'menu-item')}>
+    <th {...getAttrs(props, 'menu-item')}>
       <a href={props.href} target={props.target}>{props.children}</a>
     </th>
   );

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -5,7 +5,7 @@ import getAttrs from '../util/getAttrs';
 
 export default function Menu(props) {
   return (
-    <table {...getAttrs(props, 'table', 'menu')}>
+    <table {...getAttrs(props, 'menu')}>
       <tr>
         <td>
           <table>

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -5,7 +5,7 @@ import getAttrs from '../util/getAttrs';
 
 export default function Menu(props) {
   return (
-    <table {...getAttrs(props, 'menu')}>
+    <table {...getAttrs(props, ['children'], 'menu')}>
       <tr>
         <td>
           <table>

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -16,7 +16,7 @@ import Column from './Column';
  */
 export default function Row(props) {
   return (
-    <table {...getAttrs(props, 'row')}>
+    <table {...getAttrs(props, ['children'], 'row')}>
       <tbody>
         {/* `first` and `last` props are added to the first and last child in the row, respectively */}
         <tr>{Children.map(props.children, (child, index) => {

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -16,7 +16,7 @@ import Column from './Column';
  */
 export default function Row(props) {
   return (
-    <table {...getAttrs(props, 'table', 'row')}>
+    <table {...getAttrs(props, 'row')}>
       <tbody>
         {/* `first` and `last` props are added to the first and last child in the row, respectively */}
         <tr>{Children.map(props.children, (child, index) => {

--- a/src/components/Spacer.js
+++ b/src/components/Spacer.js
@@ -7,7 +7,9 @@ import ContainerContext from '../util/containerContext';
 const createSpacer = (props, size, state = false) => (
   <ContainerContext.Consumer>
     {({strictMode}) => (
-      <table {...getAttrs(props, classnames('spacer', state && `${state}-for-large`))}>
+      <table {...getAttrs(props, ['size', 'sizeSm', 'sizeLg', 'children'],
+        classnames('spacer', state && `${state}-for-large`))}
+      >
         <tbody>
           <tr>
             <td

--- a/src/components/Spacer.js
+++ b/src/components/Spacer.js
@@ -7,7 +7,7 @@ import ContainerContext from '../util/containerContext';
 const createSpacer = (props, size, state = false) => (
   <ContainerContext.Consumer>
     {({strictMode}) => (
-      <table {...getAttrs(props, 'table', classnames('spacer', state && `${state}-for-large`))}>
+      <table {...getAttrs(props, classnames('spacer', state && `${state}-for-large`))}>
         <tbody>
           <tr>
             <td

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -4,7 +4,7 @@ import getAttrs from '../util/getAttrs';
 
 export default function Wrapper(props) {
   return (
-    <table align="center" {...getAttrs(props, 'table', 'wrapper')}>
+    <table align="center" {...getAttrs(props, 'wrapper')}>
       <tr>
         <td className="wrapper-inner">{props.children}</td>
       </tr>

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -4,7 +4,7 @@ import getAttrs from '../util/getAttrs';
 
 export default function Wrapper(props) {
   return (
-    <table align="center" {...getAttrs(props, 'wrapper')}>
+    <table align="center" {...getAttrs(props, ['children'], 'wrapper')}>
       <tr>
         <td className="wrapper-inner">{props.children}</td>
       </tr>

--- a/src/util/__tests__/getAttrs.js
+++ b/src/util/__tests__/getAttrs.js
@@ -12,7 +12,7 @@ describe('getAttrs()', () => {
       className: 'header',
       align: 'center'
     };
-    output = getAttrs(props, 'table', 'row');
+    output = getAttrs(props, ['large', 'small'], 'row');
   });
 
   it('returns an object', () => {

--- a/src/util/getAttrs.js
+++ b/src/util/getAttrs.js
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 /**
  * Compile attributes for a component's root element, based on its tag and default class name.
  * @param {Object} props - Component props.
- * @param {String} tag - Component root element.
+ * @param {Array} excluded - List of excluded attributes.
  * @param {String} className - Component root class name.
  * @returns {Object} Filtered props.
  *
@@ -17,15 +17,20 @@ import classnames from 'classnames';
  *
  * // Only returns "style" and "className", because the other two are custom props
  * // The class "header" is added to the base "row"
- * const attrs = getAttrs(props, 'row'); // => { style: ..., className: 'row header' }
+ * const attrs = getAttrs(props, ['children'], 'row'); // => { style: ..., className: 'row header' }
  * <table {...attrs}></table>
  */
-export default function getAttrs(props, className = '') {
-  // Filter out non-HTML attributes
-  const output = Object.assign({}, props);
+export default function getAttrs(props, excluded, className = '') {
+  // Filter out attributes
+  const output = {};
+  for (const k in props) {
+    if (excluded.indexOf(k) === -1) {
+      output[k] = props[k];
+    }
+  }
 
   // Append class names in props to base classes
   output.className = classnames(className, props.className);
-  
+
   return output;
 }

--- a/src/util/getAttrs.js
+++ b/src/util/getAttrs.js
@@ -1,4 +1,3 @@
-import {filterPropsFor} from 'react-attrs-filter';
 import classnames from 'classnames';
 
 /**
@@ -18,28 +17,15 @@ import classnames from 'classnames';
  *
  * // Only returns "style" and "className", because the other two are custom props
  * // The class "header" is added to the base "row"
- * const attrs = getAttrs(props, 'table', 'row'); // => { style: ..., className: 'row header' }
+ * const attrs = getAttrs(props, 'row'); // => { style: ..., className: 'row header' }
  * <table {...attrs}></table>
  */
-export default function getAttrs(props, tag, className = '') {
+export default function getAttrs(props, className = '') {
   // Filter out non-HTML attributes
-  const output = filterPropsFor(props, tag);
+  const output = Object.assign({}, props);
 
   // Append class names in props to base classes
   output.className = classnames(className, props.className);
-
-  // `style` isn't included in `filterPropsFor` and must be copied manually
-  if (props.style) {
-    output.style = props.style;
-  }
-
-  // Same with `align` and `valign`, since they are deprecated attributes
-  if (props.align) {
-    output.align = props.align;
-  }
-  if (props.valign) {
-    output.valign = props.valign;
-  }
-
+  
   return output;
 }


### PR DESCRIPTION
New versions of React can pass all props to result html. And sometimes it very useful. Email client specific markup, or some old html attributes (as example: bgcolor). I didn't see any reason to remove it from resulting html.